### PR TITLE
chore: add a setting to control max to delete messages

### DIFF
--- a/src/Ziggurat.MongoDB/MongoDbStorage.cs
+++ b/src/Ziggurat.MongoDB/MongoDbStorage.cs
@@ -45,7 +45,7 @@ public class MongoDbStorage : IStorage
         var builder = Builders<MessageTracking>.Filter;
         var filter = builder.Lte(x => x.DateTime, DateTime.Now.AddDays(-days));
 
-         var res = await collection.DeleteManyAsync(filter);
+        var res = await collection.DeleteManyAsync(filter);
 
         return (int)res.DeletedCount;
     }

--- a/src/Ziggurat.MongoDB/MongoDbStorage.cs
+++ b/src/Ziggurat.MongoDB/MongoDbStorage.cs
@@ -37,7 +37,7 @@ public class MongoDbStorage : IStorage
         return await collection.CountDocumentsAsync(filter) > 0;
     }
 
-    public async Task<int> DeleteMessagesHistoryOltherThanAsync(int days, int maxMessagesToDelete = 0)
+    public async Task<int> DeleteMessagesHistoryOlderThanAsync(int days, int maxMessagesToDelete = 0)
     {
         var collection = _client
             .GetDatabase(ZigguratMongoDbOptions.MongoDatabaseName)

--- a/src/Ziggurat.MongoDB/MongoDbStorage.cs
+++ b/src/Ziggurat.MongoDB/MongoDbStorage.cs
@@ -37,7 +37,7 @@ public class MongoDbStorage : IStorage
         return await collection.CountDocumentsAsync(filter) > 0;
     }
 
-    public async Task<int> DeleteMessagesHistoryOltherThanAsync(int days)
+    public async Task<int> DeleteMessagesHistoryOltherThanAsync(int days, int maxMessagesToDelete = 0)
     {
         var collection = _client
             .GetDatabase(ZigguratMongoDbOptions.MongoDatabaseName)
@@ -45,7 +45,7 @@ public class MongoDbStorage : IStorage
         var builder = Builders<MessageTracking>.Filter;
         var filter = builder.Lte(x => x.DateTime, DateTime.Now.AddDays(-days));
 
-        var res = await collection.DeleteManyAsync(filter);
+         var res = await collection.DeleteManyAsync(filter);
 
         return (int)res.DeletedCount;
     }

--- a/src/Ziggurat.SqlServer/EntityFrameworkStorage.cs
+++ b/src/Ziggurat.SqlServer/EntityFrameworkStorage.cs
@@ -56,7 +56,7 @@ public class EntityFrameworkStorage<TContext> : IStorage
                 "Cannot create IdempotencyService because a DbSet for 'MessageTracking' is not included in the model for the context.");
     }
 
-    public async Task<int> DeleteMessagesHistoryOltherThanAsync(int days, int maxMessagesToDelete = 0)
+    public async Task<int> DeleteMessagesHistoryOlderThanAsync(int days, int maxMessagesToDelete = 0)
     {
         var messagesToDeleteInDb = _messages
            .Where(x => x.DateTime <= DateTime.Now.AddDays(-days));

--- a/src/Ziggurat/Cleaner/StorageCleanerMiddleware.cs
+++ b/src/Ziggurat/Cleaner/StorageCleanerMiddleware.cs
@@ -52,7 +52,7 @@ namespace Ziggurat.Cleaner
         {
             try
             {
-                var deleteCount = await _storage.DeleteMessagesHistoryOltherThanAsync(deleteOltherThanDays, maxMessagesToDelete);
+                var deleteCount = await _storage.DeleteMessagesHistoryOlderThanAsync(deleteOltherThanDays, maxMessagesToDelete);
                 _logger.LogInformation("Deleted {deleteCount} messages older than {olderThanDays} days.", deleteCount, deleteOltherThanDays);
             }
             catch (Exception ex)

--- a/src/Ziggurat/Idempotency/IStorage.cs
+++ b/src/Ziggurat/Idempotency/IStorage.cs
@@ -9,5 +9,5 @@ public interface IStorage
 
     Task<bool> HasProcessedAsync(IMessage message);
 
-    Task<int> DeleteMessagesHistoryOltherThanAsync(int days, int maxMessagesToDelete = 0);
+    Task<int> DeleteMessagesHistoryOlderThanAsync(int days, int maxMessagesToDelete = 0);
 }

--- a/src/Ziggurat/Idempotency/IStorage.cs
+++ b/src/Ziggurat/Idempotency/IStorage.cs
@@ -9,5 +9,5 @@ public interface IStorage
 
     Task<bool> HasProcessedAsync(IMessage message);
 
-    Task<int> DeleteMessagesHistoryOltherThanAsync(int days);
+    Task<int> DeleteMessagesHistoryOltherThanAsync(int days, int maxMessagesToDelete = 0);
 }

--- a/src/Ziggurat/ServiceCollectionExtensions.cs
+++ b/src/Ziggurat/ServiceCollectionExtensions.cs
@@ -35,9 +35,9 @@ public static class ServiceCollectionExtensions
     /// Extension Method for implementing Middleware to clean Messages history
     /// </summary>
     /// <param name="app">the IApplicationBuilder</param>
-    /// <param name="deleteOltherThanDays">The number of days max history allowed so that cleans older than those, deafults to 15 days</param>
+    /// <param name="deleteOlderThanDays ">The number of days max history allowed so that cleans older than those, deafults to 15 days</param>
     /// <param name="maxMessagesToDelete">The max number of messages to delete in history in case needed to avoid time consuming task if not specified will take 0 meaning no constrain</param>
     /// <returns>Returns the Middleware implementation</returns>
-    public static IApplicationBuilder UseZigguratCleaner(this IApplicationBuilder app, int deleteOltherThanDays = 15, int maxMessagesToDelete = 0) =>
-        app.UseMiddleware<StorageCleanerMiddleware>(deleteOltherThanDays, maxMessagesToDelete);
+    public static IApplicationBuilder UseZigguratCleaner(this IApplicationBuilder app, int deleteOlderThanDays = 15, int maxMessagesToDelete = 0) =>
+        app.UseMiddleware<StorageCleanerMiddleware>(deleteOlderThanDays, maxMessagesToDelete);
 }

--- a/src/Ziggurat/ServiceCollectionExtensions.cs
+++ b/src/Ziggurat/ServiceCollectionExtensions.cs
@@ -36,7 +36,8 @@ public static class ServiceCollectionExtensions
     /// </summary>
     /// <param name="app">the IApplicationBuilder</param>
     /// <param name="deleteOltherThanDays">The number of days max history allowed so that cleans older than those, deafults to 15 days</param>
+    /// <param name="maxMessagesToDelete">The max number of messages to delete in history in case needed to avoid time consuming task if not specified will take 0 meaning no constrain</param>
     /// <returns>Returns the Middleware implementation</returns>
-    public static IApplicationBuilder UseZigguratCleaner(this IApplicationBuilder app, int deleteOltherThanDays = 15) =>
-        app.UseMiddleware<StorageCleanerMiddleware>(deleteOltherThanDays);
+    public static IApplicationBuilder UseZigguratCleaner(this IApplicationBuilder app, int deleteOltherThanDays = 15, int maxMessagesToDelete = 0) =>
+        app.UseMiddleware<StorageCleanerMiddleware>(deleteOltherThanDays, maxMessagesToDelete);
 }

--- a/tests/Ziggurat.MongoDB.Tests/MongoDbStorageTests.cs
+++ b/tests/Ziggurat.MongoDB.Tests/MongoDbStorageTests.cs
@@ -180,7 +180,7 @@ public class MongoDbStorageTests : TestFixture
         }
 
         // Act       
-        await _storage.DeleteMessagesHistoryOltherThanAsync(30);
+        await _storage.DeleteMessagesHistoryOlderThanAsync(30);
 
         // Assert
         for (var i = 1; i < 7; i++)

--- a/tests/Ziggurat.SqlServer.Tests/EntityFrameworkStorageTests.cs
+++ b/tests/Ziggurat.SqlServer.Tests/EntityFrameworkStorageTests.cs
@@ -175,7 +175,7 @@ public class EntityFrameworkStorageTests : TestFixture
     }
 
     [Fact]
-    public async Task IsDeleteHistoryMessages_OltherThan30Days_ShouldUpdateDatabase()
+    public async Task IsDeleteHistoryMessages_OlderThan30Days_ShouldUpdateDatabase()
     {
         // Arrange
         var dbRealContext = new TestDbContext();
@@ -212,7 +212,7 @@ public class EntityFrameworkStorageTests : TestFixture
     }
 
     [Fact]
-    public async Task IsDeleteHistoryMessages_OltherThan30DaysMax2_ShouldUpdateDatabase()
+    public async Task IsDeleteHistoryMessages_OlderThan30DaysMax2_ShouldUpdateDatabase()
     {
         // Arrange
         var dbRealContext = new TestDbContext();

--- a/tests/Ziggurat.SqlServer.Tests/EntityFrameworkStorageTests.cs
+++ b/tests/Ziggurat.SqlServer.Tests/EntityFrameworkStorageTests.cs
@@ -194,7 +194,7 @@ public class EntityFrameworkStorageTests : TestFixture
         await dbRealContext.Database.ExecuteSqlInterpolatedAsync($"UPDATE MessageTracking SET DateTime = {DateTime.Now.AddDays(-60)} WHERE Id IN ('1436814771495108604','1436814771495108605','1436814771495108606')");
 
         // Act
-        await storageWithRealDbContext.DeleteMessagesHistoryOltherThanAsync(30);
+        await storageWithRealDbContext.DeleteMessagesHistoryOlderThanAsync(30);
         await dbRealContext.SaveChangesAsync();
 
         // Assert


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the cleanup process by adding the ability to specify the maximum number of messages to delete, improving control and efficiency.
- **Refactor**
	- Improved code structure and readability in components related to message history deletion.
- **Tests**
	- Updated test methods to reflect changes in the method name and functionality for message history deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->